### PR TITLE
Add python.app as dependency on mac

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - appnope              # [osx]
     - pyreadline           # [win]
     - backports.shutil_get_terminal_size
+    - python.app           # [osx]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: python -m pip install --no-deps .
-  number: 1
+  number: 2
   entry_points:
     - ipython = IPython:start_ipython
     - ipython2 = IPython:start_ipython  # [py2k]


### PR DESCRIPTION
Without this, ipython fails on launch with the error:

```
/bin/bash: /Users/mcraig/anaconda/envs/ipy-wtf/bin/python.app: No such file or directory
```
